### PR TITLE
[fix]エラーメッセージが出た際のransackのバグ修正 #5

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,7 +20,10 @@ class PostsController < ApplicationController
     if @post.save
       redirect_to @post, notice: "successfully created post!"
     else
+      @post = Post.new
       @posts = Post.all
+      @q = Post.ransack(params[:q])
+      @posts = @q.result(distinct: true)
       render action: :index
     end
   end


### PR DESCRIPTION
- renderした際に、posts#createで下記の変数に代入がなかったためエラーが起きていた
```ruby
    @q = Post.ransack(params[:q])
    @posts = @q.result(distinct: true)
```